### PR TITLE
fix: improve responsiveness and add lazy loading to the popup contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@promotedai/react-introspection",
-  "main": "dist/react-introspection.esm.js",
+  "main": "dist/",
   "version": "1.0.0",
   "description": "Promoted Introspection integration for React web apps",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,14 +15,6 @@ export default [
       }),
       terser(),
     ],
-    output: [
-      {
-        name: pkg.name,
-        file: `dist/react-introspection.umd.js`,
-        format: 'umd',
-        sourcemap: true,
-      },
-      { file: `dist/react-introspection.esm.js`, format: 'es', sourcemap: true },
-    ],
+    output: [{ dir: 'dist', format: 'es', sourcemap: true }],
   },
 ]

--- a/src/Cell/CellPopup.tsx
+++ b/src/Cell/CellPopup.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, useState } from 'react'
+import React, { SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Box, Tab, Tabs, ThemeProvider } from '@material-ui/core'
 import { createTheme } from '@material-ui/core'
 import { ModerationPanel } from './ModerationPanel'
@@ -10,6 +10,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { blue } from '@material-ui/core/colors'
 
 export interface CellPopupArgs {
+  triggerContainerRef: React.RefObject<HTMLDivElement>
   introspectionData: CellIntrospectionData
   handleClose: () => any
 }
@@ -17,13 +18,9 @@ export interface CellPopupArgs {
 const useStyles = makeStyles((theme) => ({
   outerContainer: {
     color: 'black',
-    left: '-412px',
-    padding: '20px',
-    position: 'absolute',
-    top: '50%',
-    transform: 'translateY(-50%)',
     width: '400px',
     zIndex: 1001,
+    maxHeight: '100vh',
   },
   innerContainer: {
     background: '#eee',
@@ -48,7 +45,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-export const CellPopup = ({ introspectionData, handleClose }: CellPopupArgs) => {
+export const CellPopup = ({ triggerContainerRef, introspectionData, handleClose }: CellPopupArgs) => {
   const theme = createTheme({
     typography: {
       body1: {
@@ -59,6 +56,8 @@ export const CellPopup = ({ introspectionData, handleClose }: CellPopupArgs) => 
       primary: blue,
     },
   })
+
+  const popupContainerRef = useRef<HTMLDivElement>(null)
 
   const classes = useStyles(theme)
 
@@ -71,36 +70,72 @@ export const CellPopup = ({ introspectionData, handleClose }: CellPopupArgs) => 
     setPromotedLogoVisible(visible)
   }
 
+  const repositionPopup = useCallback(() => {
+    if (!triggerContainerRef.current || !popupContainerRef.current) return
+    const triggerRect = triggerContainerRef.current.getBoundingClientRect()
+    const popupRect = popupContainerRef.current.getBoundingClientRect()
+
+    popupContainerRef.current.style.position = 'absolute'
+    popupContainerRef.current.style.left = `${-Math.min(popupRect.width + 25, triggerRect.x)}px`
+    popupContainerRef.current.style.top = `${-(popupRect.height - triggerRect.height) / 2}px`
+  }, [])
+
+  useEffect(() => {
+    repositionPopup()
+  }, [repositionPopup])
+
+  const resizeObserver = useMemo(() => {
+    return new ResizeObserver(() => {
+      repositionPopup()
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!popupContainerRef.current) return
+
+    resizeObserver.observe(popupContainerRef.current)
+    window.addEventListener('resize', repositionPopup)
+
+    return () => {
+      if (popupContainerRef.current) {
+        resizeObserver.unobserve(popupContainerRef.current)
+      }
+      window.removeEventListener('resize', repositionPopup)
+    }
+  }, [])
+
   return (
     <ThemeProvider theme={theme}>
-      <Box className={classes.outerContainer}>
-        <Box boxShadow={4} className={classes.innerContainer}>
-          <Box className={classes.callout} />
-          <Tabs onChange={handleTabChange} value={tabIndex} variant="scrollable" indicatorColor="primary">
-            <Tab label="Stats" />
-            <Tab label="Properties" />
-            <Tab label="Moderation" />
-            <Tab label="Moderation Log" />
-          </Tabs>
-          {promotedLogoVisible && (
-            <img className={classes.promotedLogo} src="https://avatars.githubusercontent.com/t/3500892?s=280&v=4" />
-          )}
+      <div ref={popupContainerRef}>
+        <Box className={classes.outerContainer}>
+          <Box boxShadow={4} className={classes.innerContainer}>
+            <Box className={classes.callout} />
+            <Tabs onChange={handleTabChange} value={tabIndex} variant="scrollable" indicatorColor="primary">
+              <Tab label="Stats" />
+              <Tab label="Properties" />
+              <Tab label="Moderation" />
+              <Tab label="Moderation Log" />
+            </Tabs>
+            {promotedLogoVisible && (
+              <img className={classes.promotedLogo} src="https://avatars.githubusercontent.com/t/3500892?s=280&v=4" />
+            )}
 
-          {tabIndex == 0 && (
-            <StatsPanel
-              introspectionData={introspectionData}
-              handleCopyButtonVisibilityChange={handleCopyButtonVisibilityChange}
-              handleClose={handleClose}
-              theme={theme}
-            />
-          )}
+            {tabIndex == 0 && (
+              <StatsPanel
+                introspectionData={introspectionData}
+                handleCopyButtonVisibilityChange={handleCopyButtonVisibilityChange}
+                handleClose={handleClose}
+                theme={theme}
+              />
+            )}
 
-          {tabIndex == 1 && <PropertiesPanel handleClose={handleClose} theme={theme} />}
+            {tabIndex == 1 && <PropertiesPanel handleClose={handleClose} theme={theme} />}
 
-          {tabIndex == 2 && <ModerationPanel handleClose={handleClose} theme={theme} />}
-          {tabIndex == 3 && <ModerationLogPanel handleClose={handleClose} theme={theme} />}
+            {tabIndex == 2 && <ModerationPanel handleClose={handleClose} theme={theme} />}
+            {tabIndex == 3 && <ModerationLogPanel handleClose={handleClose} theme={theme} />}
+          </Box>
         </Box>
-      </Box>
+      </div>
     </ThemeProvider>
   )
 }

--- a/src/Cell/CellPopup.tsx
+++ b/src/Cell/CellPopup.tsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles((theme) => ({
   },
   outerContainer: {
     color: 'black',
+    maxWidth: '100vw',
     width: '400px',
     zIndex: 1001,
     maxHeight: '100vh',
@@ -33,6 +34,10 @@ const useStyles = makeStyles((theme) => ({
     position: 'relative',
   },
   callout: {
+    display: 'none',
+    [theme.breakpoints.up('sm')]: {
+      display: 'block',
+    },
     backgroundColor: '#eee',
     transform: 'rotate(45deg) translateX(-50%)',
     height: '30px',

--- a/src/Cell/CellPopup.tsx
+++ b/src/Cell/CellPopup.tsx
@@ -16,6 +16,11 @@ export interface CellPopupArgs {
 }
 
 const useStyles = makeStyles((theme) => ({
+  popupContainer: {
+    position: 'absolute',
+    left: '-425px',
+    top: '-41%',
+  },
   outerContainer: {
     color: 'black',
     width: '400px',
@@ -74,7 +79,6 @@ export const CellPopup = ({ triggerContainerRef, introspectionData, handleClose 
     if (!triggerContainerRef.current || !popupContainerRef.current) return
     const triggerRect = triggerContainerRef.current.getBoundingClientRect()
     const popupRect = popupContainerRef.current.getBoundingClientRect()
-
     popupContainerRef.current.style.position = 'absolute'
     popupContainerRef.current.style.left = `${-Math.min(popupRect.width + 25, triggerRect.x)}px`
     popupContainerRef.current.style.top = `${-(popupRect.height - triggerRect.height) / 2}px`
@@ -106,7 +110,7 @@ export const CellPopup = ({ triggerContainerRef, introspectionData, handleClose 
 
   return (
     <ThemeProvider theme={theme}>
-      <div ref={popupContainerRef}>
+      <div ref={popupContainerRef} className={classes.popupContainer}>
         <Box className={classes.outerContainer}>
           <Box boxShadow={4} className={classes.innerContainer}>
             <Box className={classes.callout} />

--- a/src/Cell/PromotedIntrospectionCell.stories.tsx
+++ b/src/Cell/PromotedIntrospectionCell.stories.tsx
@@ -39,6 +39,7 @@ const Template: ComponentStory<typeof PromotedIntrospectionCell> = (args) => (
 export const Default = Template.bind({})
 
 Default.args = {
+  introspectionEndpoint: 'www.foo.com',
   item: {
     insertionId: 'abc',
   },
@@ -85,21 +86,7 @@ export const TriggerOverlay = () => {
       <PromotedIntrospectionCell
         item={{ insertionId: 'abc' }}
         introspectionEndpoint="www.foo.com"
-        triggerType={PromotedIntrospectionCellTrigger.OverlayAlways}
-      >
-        <SearchItem />
-      </PromotedIntrospectionCell>
-    </div>
-  )
-}
-
-export const TriggerOverlayOnHover = () => {
-  return (
-    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
-      <PromotedIntrospectionCell
-        item={{ insertionId: 'abc' }}
-        introspectionEndpoint="www.foo.com"
-        triggerType={PromotedIntrospectionCellTrigger.OverlayOnMouseEnter}
+        triggerType={PromotedIntrospectionCellTrigger.Overlay}
       >
         <SearchItem />
       </PromotedIntrospectionCell>

--- a/src/Cell/PromotedIntrospectionCell.stories.tsx
+++ b/src/Cell/PromotedIntrospectionCell.stories.tsx
@@ -38,3 +38,50 @@ Default.args = {
     insertionId: 'abc',
   },
 }
+
+export const CustomTrigger = Template.bind({})
+
+CustomTrigger.args = {
+  introspectionEndpoint: 'www.foo.com',
+  item: {
+    insertionId: 'abc',
+  },
+  renderTrigger: (onTrigger: () => any) => {
+    return (
+      <button style={{ position: 'absolute', top: 5, left: 5 }} onClick={onTrigger}>
+        trigger
+      </button>
+    )
+  },
+}
+
+export const Controlled = () => {
+  const [isOpen, setIsOpen] = React.useState(false)
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+      <button onClick={() => setIsOpen(true)}>Open</button>
+      <PromotedIntrospectionCell
+        isOpen={isOpen}
+        disableDefaultTrigger
+        item={{ insertionId: 'abc' }}
+        introspectionEndpoint="www.foo.com"
+        onClose={() => setIsOpen(false)}
+      >
+        <Card
+          style={{
+            height: 300,
+            width: 200,
+            textAlign: 'center',
+            alignItems: 'center',
+            justifyContent: 'center',
+            display: 'flex',
+            margin: 'auto',
+          }}
+        >
+          Some search result
+        </Card>
+      </PromotedIntrospectionCell>
+    </div>
+  )
+}

--- a/src/Cell/PromotedIntrospectionCell.stories.tsx
+++ b/src/Cell/PromotedIntrospectionCell.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { PromotedIntrospectionCell } from './PromotedIntrospectionCell'
+import { PromotedIntrospectionCell, PromotedIntrospectionCellTrigger } from './PromotedIntrospectionCell'
 import { Card } from '@material-ui/core'
 
 export default {
@@ -10,22 +10,28 @@ export default {
   component: PromotedIntrospectionCell,
 } as ComponentMeta<typeof PromotedIntrospectionCell>
 
+const SearchItem = () => {
+  return (
+    <Card
+      style={{
+        height: 300,
+        width: 200,
+        textAlign: 'center',
+        alignItems: 'center',
+        justifyContent: 'center',
+        display: 'flex',
+        margin: 'auto',
+      }}
+    >
+      Some search result
+    </Card>
+  )
+}
+
 const Template: ComponentStory<typeof PromotedIntrospectionCell> = (args) => (
   <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
     <PromotedIntrospectionCell {...args}>
-      <Card
-        style={{
-          height: 300,
-          width: 200,
-          textAlign: 'center',
-          alignItems: 'center',
-          justifyContent: 'center',
-          display: 'flex',
-          margin: 'auto',
-        }}
-      >
-        Some search result
-      </Card>
+      <SearchItem />
     </PromotedIntrospectionCell>
   </div>
 )
@@ -33,7 +39,6 @@ const Template: ComponentStory<typeof PromotedIntrospectionCell> = (args) => (
 export const Default = Template.bind({})
 
 Default.args = {
-  introspectionEndpoint: 'www.foo.com',
   item: {
     insertionId: 'abc',
   },
@@ -68,19 +73,35 @@ export const Controlled = () => {
         introspectionEndpoint="www.foo.com"
         onClose={() => setIsOpen(false)}
       >
-        <Card
-          style={{
-            height: 300,
-            width: 200,
-            textAlign: 'center',
-            alignItems: 'center',
-            justifyContent: 'center',
-            display: 'flex',
-            margin: 'auto',
-          }}
-        >
-          Some search result
-        </Card>
+        <SearchItem />
+      </PromotedIntrospectionCell>
+    </div>
+  )
+}
+
+export const TriggerOverlay = () => {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+      <PromotedIntrospectionCell
+        item={{ insertionId: 'abc' }}
+        introspectionEndpoint="www.foo.com"
+        triggerType={PromotedIntrospectionCellTrigger.OverlayAlways}
+      >
+        <SearchItem />
+      </PromotedIntrospectionCell>
+    </div>
+  )
+}
+
+export const TriggerOverlayOnHover = () => {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+      <PromotedIntrospectionCell
+        item={{ insertionId: 'abc' }}
+        introspectionEndpoint="www.foo.com"
+        triggerType={PromotedIntrospectionCellTrigger.OverlayOnMouseEnter}
+      >
+        <SearchItem />
       </PromotedIntrospectionCell>
     </div>
   )

--- a/src/Cell/PromotedIntrospectionCell.stories.tsx
+++ b/src/Cell/PromotedIntrospectionCell.stories.tsx
@@ -93,3 +93,17 @@ export const TriggerOverlay = () => {
     </div>
   )
 }
+
+export const TriggerOverlayOnHover = () => {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+      <PromotedIntrospectionCell
+        item={{ insertionId: 'abc' }}
+        introspectionEndpoint="www.foo.com"
+        triggerType={PromotedIntrospectionCellTrigger.OverlayOnHover}
+      >
+        <SearchItem />
+      </PromotedIntrospectionCell>
+    </div>
+  )
+}

--- a/src/Cell/PromotedIntrospectionCell.tsx
+++ b/src/Cell/PromotedIntrospectionCell.tsx
@@ -11,6 +11,7 @@ const CellPopup = React.lazy(() => import('./CellPopup').then(({ CellPopup }) =>
 export enum PromotedIntrospectionCellTrigger {
   ContextMenu = 1,
   Overlay = 2,
+  OverlayOnHover = 3,
 }
 
 export interface PromotedIntrospectionCellArgs {
@@ -23,6 +24,8 @@ export interface PromotedIntrospectionCellArgs {
   onClose?: () => any
   triggerType?: PromotedIntrospectionCellTrigger
 }
+
+const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
 
 export const PromotedIntrospectionCell = ({
   item,
@@ -91,20 +94,44 @@ export const PromotedIntrospectionCell = ({
     body.style.overflow = contextMenuOpen && introspectionEndpoint ? 'hidden' : 'initial'
   }, [contextMenuOpen])
 
+  const [showTriggerOverlay, setShowTriggerOverlay] = useState(
+    () =>
+      triggerType === PromotedIntrospectionCellTrigger.Overlay ||
+      (triggerType === PromotedIntrospectionCellTrigger.OverlayOnHover && isMobile)
+  )
+
+  // This could be done with a :hover pseudoselector, but we're restricted to inline CSS unless we import a
+  // CSS-in-JS library (which we want to avoid in this file), or use a separate CSS file that the client would have to import.
+  const onMouseEnter = () => {
+    if (triggerType === PromotedIntrospectionCellTrigger.OverlayOnHover && !isMobile) {
+      setShowTriggerOverlay(true)
+    }
+  }
+
+  const onMouseLeave = () => {
+    if (triggerType === PromotedIntrospectionCellTrigger.OverlayOnHover && !isMobile) {
+      setShowTriggerOverlay(false)
+    }
+  }
+
   return (
     <>
       <div
         onContextMenu={
           !disableDefaultTrigger && triggerType === PromotedIntrospectionCellTrigger.ContextMenu ? onTrigger : undefined
         }
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         style={{
           position: 'relative',
           ...(contextMenuOpen ? { background: 'white', zIndex: 1000 } : {}),
         }}
       >
-        {triggerType === PromotedIntrospectionCellTrigger.Overlay && (
+        {(triggerType === PromotedIntrospectionCellTrigger.Overlay ||
+          triggerType === PromotedIntrospectionCellTrigger.OverlayOnHover) && (
           <button
             style={{
+              display: showTriggerOverlay ? 'block' : 'none',
               padding: '5px',
               border: 'none',
               position: 'absolute',

--- a/src/Cell/StatsPanel.tsx
+++ b/src/Cell/StatsPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Button, makeStyles, Typography } from '@material-ui/core'
+import { Box, Button, makeStyles, Typography, Tooltip } from '@material-ui/core'
 import { Theme } from '@material-ui/core'
 import { CSSProperties } from '@material-ui/core/styles/withStyles'
 import { useState } from 'react'
@@ -70,28 +70,76 @@ export const StatsPanel = ({
   const classes = useStyles(theme)
 
   const ids = [
-    ['User ID', userId],
-    ['Log User ID', logUserId],
-    ['Request ID', requestId],
-    ['Insertion ID', insertionId],
+    {
+      label: 'User ID',
+      value: userId,
+    },
+    {
+      label: 'Log User ID',
+      value: logUserId,
+    },
+    {
+      label: 'Request ID',
+      value: requestId,
+    },
+    {
+      label: 'Insertion ID',
+      value: insertionId,
+    },
   ]
+
   const ranks = [
-    ['Promoted', promotedRank],
-    ['Retrieval', `${retrievalRank} (${formatting.difference((retrievalRank ?? 0) - (promotedRank ?? 0))})`],
+    {
+      label: 'Promoted',
+      value: promotedRank,
+    },
+    {
+      label: 'Retrieval',
+      value: `${retrievalRank} (${formatting.difference((retrievalRank ?? 0) - (promotedRank ?? 0))})`,
+    },
   ]
+
   const stats = [
-    ['p(Click)', pClick],
-    ['p(Purchase)', pPurchase],
-    ['30 Day Impr', queryRelevance],
-    ['CTR', queryRelevance],
-    ['Post-Click CVR', queryRelevance],
-    ['Personalization', personalization],
-    ['Price', queryRelevance],
+    {
+      label: 'p(Click)',
+      value: pClick,
+      tooltip: 'Probability of a click',
+    },
+    {
+      label: 'p(Purchase)',
+      value: pPurchase,
+      tooltip: 'Probability of a purchase',
+    },
+    {
+      label: '30 Day Impr',
+      value: queryRelevance,
+      tooltip: '30 Day Impressions',
+    },
+    {
+      label: 'CTR',
+      value: queryRelevance,
+      tooltip: 'Click Through Rate',
+    },
+    {
+      label: 'Post-Click CVR',
+      value: queryRelevance,
+      tooltip: 'Post-Click Conversion Rate',
+    },
+    {
+      label: 'Personalization',
+      value: personalization,
+      tooltip: 'Personalization',
+    },
+    {
+      label: 'Price',
+      value: queryRelevance,
+      tooltip: 'Price',
+    },
   ]
 
   const introspectionRows = (
     title: string,
-    content: (string | number | undefined)[][],
+    content: { label: string; value: string | number | undefined; tooltip?: string | undefined }[],
     labelColumns: any,
     contentColumns: any
   ) => (
@@ -102,10 +150,17 @@ export const StatsPanel = ({
       {content.map((item) => (
         <>
           <Box sx={{ ...statsStyles.itemLabel, gridColumn: labelColumns }}>
-            <Typography>{item[0]}:</Typography>
+            <Typography>
+              {item.tooltip && (
+                <Tooltip arrow title={item.tooltip}>
+                  <span>{item.label}</span>
+                </Tooltip>
+              )}
+            </Typography>
+            {!item.tooltip && <Typography>{item.label}</Typography>}
           </Box>
           <Box sx={{ ...statsStyles.itemContent, gridColumn: contentColumns }}>
-            <Typography>{item[1] ?? '-'}</Typography>
+            <Typography>{item.value ?? '-'}</Typography>
           </Box>
         </>
       ))}

--- a/src/withPromotedIntrospection.stories.tsx
+++ b/src/withPromotedIntrospection.stories.tsx
@@ -42,3 +42,21 @@ Default.args = {
     insertionId: 'abc',
   },
 }
+
+export const Controlled = () => {
+  const [isOpen, setIsOpen] = React.useState(false)
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+      <button onClick={() => setIsOpen(true)}>Open</button>
+      <WithPromotedIntrospection
+        introspectionOpen={isOpen}
+        introspectionEnabled
+        disableDefaultIntrospectionTrigger
+        item={{ insertionId: 'abc' }}
+        introspectionEndpoint="www.foo.com"
+        onIntrospectionClose={() => setIsOpen(false)}
+      />
+    </div>
+  )
+}

--- a/src/withPromotedIntrospection.tsx
+++ b/src/withPromotedIntrospection.tsx
@@ -7,7 +7,14 @@ export const withPromotedIntrospection =
     const WithPromotedIntrospection = (props: any) => {
       if (props.introspectionEnabled) {
         return (
-          <PromotedIntrospectionCell item={props.item} introspectionEndpoint={introspectionEndpoint}>
+          <PromotedIntrospectionCell
+            item={props.item}
+            introspectionEndpoint={introspectionEndpoint}
+            isOpen={props.introspectionOpen}
+            renderTrigger={props.renderIntrospectionTrigger}
+            onClose={props.onIntrospectionClose}
+            disableDefaultTrigger={props.disableDefaultIntrospectionTrigger}
+          >
             <WrappedComponent {...props} />
           </PromotedIntrospectionCell>
         )


### PR DESCRIPTION
Adds some math to better position the popup on screen resizing (no more disappearing over the edge of the screen, etc).

Also now allows for passing in a custom trigger as a renderprop.  This may be useful on mobile devices especially, since the contextmenu isn't something that can be triggered.  We may want to add a default trigger for mobile, however, so it's a little more effective right out of the box.