### PR TITLE
fix: remove references to navigator and allow scrolling while popup is open

### DIFF
--- a/src/PromotedIntrospection/PromotedIntrospection.tsx
+++ b/src/PromotedIntrospection/PromotedIntrospection.tsx
@@ -44,7 +44,9 @@ export enum REQUEST_ERRORS {
   FETCH_FAILED = 'FETCH_FAILED',
 }
 
-const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+// TODO: investigate why navigator is undefined
+// const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+const isMobile = false
 
 export const PromotedIntrospection = ({
   item,
@@ -135,13 +137,6 @@ export const PromotedIntrospection = ({
     e.preventDefault()
     handleClose()
   }
-
-  useEffect(() => {
-    const body = document.querySelector('body')
-    if (!body) return
-
-    body.style.overflow = contextMenuOpen && endpoint ? 'hidden' : 'initial'
-  }, [contextMenuOpen])
 
   const [showTriggerOverlay, setShowTriggerOverlay] = useState(
     () =>

--- a/src/PromotedIntrospection/StatsPanel.tsx
+++ b/src/PromotedIntrospection/StatsPanel.tsx
@@ -103,22 +103,22 @@ export const StatsPanel = ({
   const handleCopyIds = () => {
     setCopyButtonVisible(false)
     handleCopyButtonVisibilityChange(false)
-    navigator.clipboard.writeText(
-      JSON.stringify({
-        ids: introspectionIds.map((id) => ({
-          label: id.label,
-          value: id.value ?? '-',
-        })),
-        ranks: ranks.map((rank) => ({
-          label: rank.label,
-          value: rank.value(introspectionData) ?? '-',
-        })),
-        statistics: statistics.map((statistic) => ({
-          label: statistic.label,
-          value: statistic.value(introspectionData) ?? '-',
-        })),
-      })
-    )
+    // navigator.clipboard.writeText(
+    //   JSON.stringify({
+    //     ids: introspectionIds.map((id) => ({
+    //       label: id.label,
+    //       value: id.value ?? '-',
+    //     })),
+    //     ranks: ranks.map((rank) => ({
+    //       label: rank.label,
+    //       value: rank.value(introspectionData) ?? '-',
+    //     })),
+    //     statistics: statistics.map((statistic) => ({
+    //       label: statistic.label,
+    //       value: statistic.value(introspectionData) ?? '-',
+    //     })),
+    //   })
+    // )
     setTimeout(() => {
       setCopyButtonVisible(true)
       handleCopyButtonVisibilityChange(true)


### PR DESCRIPTION
It's possibly something to do with our rollup config, because at the moment there doesn't seem to be a way to reference `window` or `navigator`, and this has some odd effects for the consumer.  Just going to disable this for the war room so I can do a little more research.

This also may have something to do with the way our client is prerendering, so the workaround is possibly on their end.