### PR TITLE
fix: apply class prefixes in all environments

### DIFF
--- a/src/PromotedIntrospection/Popup.tsx
+++ b/src/PromotedIntrospection/Popup.tsx
@@ -80,7 +80,7 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 const generateClassName = createGenerateClassName({
-  productionPrefix: 'promoted-introspection',
+  seed: 'promoted-introspection',
 })
 
 export const Popup = ({


### PR DESCRIPTION
The previous fix will only apply the prefix when `NODE_ENV=production`.  It will now apply it regardless of the NODE_ENV.