### PR TITLE
fix: add a more robust copy mechanism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.11.3",
-        "@material-ui/utils": "^4.11.3"
+        "@material-ui/utils": "^4.11.3",
+        "copy-to-clipboard": "^3.3.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^11.0.0",
@@ -11545,6 +11546,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.2.tgz",
+      "integrity": "sha512-Vme1Z6RUDzrb6xAI7EZlVZ5uvOk2F//GaxKUxajDqm9LhOVM1inxNAD2vy+UZDYsd0uyA9s7b3/FVZPSxqrCfg==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
       }
     },
     "node_modules/core-js": {
@@ -29457,6 +29466,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -40048,6 +40062,14 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
+    },
+    "copy-to-clipboard": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.2.tgz",
+      "integrity": "sha512-Vme1Z6RUDzrb6xAI7EZlVZ5uvOk2F//GaxKUxajDqm9LhOVM1inxNAD2vy+UZDYsd0uyA9s7b3/FVZPSxqrCfg==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "core-js": {
       "version": "3.25.1",
@@ -53744,6 +53766,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@promotedai/react-introspection",
   "main": "dist/",
-  "version": "1.3.9",
+  "version": "1.4.1",
   "description": "Promoted Introspection integration for React web apps",
   "scripts": {
     "prettier": "prettier '**/*.{js,ts}' --ignore-path ./.prettierignore",
@@ -57,7 +57,8 @@
   "dependencies": {
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
-    "@material-ui/utils": "^4.11.3"
+    "@material-ui/utils": "^4.11.3",
+    "copy-to-clipboard": "^3.3.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || 17 || 18",

--- a/src/PromotedIntrospection/StatsPanel.tsx
+++ b/src/PromotedIntrospection/StatsPanel.tsx
@@ -7,6 +7,7 @@ import { Checkmark } from './Checkmark'
 import { styles } from './styles'
 import { IntrospectionData } from './types'
 import { IntrospectionIds } from './Popup'
+import copy from 'copy-to-clipboard'
 import { ranks, statistics } from '../constants'
 
 export interface StatsPanelArgs {
@@ -103,24 +104,22 @@ export const StatsPanel = ({
   const handleCopyIds = () => {
     setCopyButtonVisible(false)
     handleCopyButtonVisibilityChange(false)
-    if (typeof navigator !== 'undefined') {
-      navigator.clipboard.writeText(
-        JSON.stringify({
-          ids: introspectionIds.map((id) => ({
-            label: id.label,
-            value: id.value ?? '-',
-          })),
-          ranks: ranks.map((rank) => ({
-            label: rank.label,
-            value: rank.value(introspectionData) ?? '-',
-          })),
-          statistics: statistics.map((statistic) => ({
-            label: statistic.label,
-            value: statistic.value(introspectionData) ?? '-',
-          })),
-        })
-      )
-    }
+    copy(
+      JSON.stringify({
+        ids: introspectionIds.map((id) => ({
+          label: id.label,
+          value: id.value ?? '-',
+        })),
+        ranks: ranks.map((rank) => ({
+          label: rank.label,
+          value: rank.value(introspectionData) ?? '-',
+        })),
+        statistics: statistics.map((statistic) => ({
+          label: statistic.label,
+          value: statistic.value(introspectionData) ?? '-',
+        })),
+      })
+    )
     setTimeout(() => {
       setCopyButtonVisible(true)
       handleCopyButtonVisibilityChange(true)


### PR DESCRIPTION
Tested in storybook.  

This came about because the Terser webpack plugin determines that the previous code block was dead code and removes it during our client's build process.  Instead of just working around Terser, it makes sense to also use a more robust copy mechanism that works across more browsers.  Terser shouldn't see any of this as dead code.